### PR TITLE
Added intent extra for pre-rotating the image

### DIFF
--- a/simple-crop-image-example/src/eu/janmuller/android/simplecropimage/example/MainActivity.java
+++ b/simple-crop-image-example/src/eu/janmuller/android/simplecropimage/example/MainActivity.java
@@ -11,6 +11,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.media.ExifInterface;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
@@ -104,6 +105,36 @@ public class MainActivity extends Activity {
         Intent intent = new Intent(this, CropImage.class);
         intent.putExtra(CropImage.IMAGE_PATH, mFileTemp.getPath());
         intent.putExtra(CropImage.SCALE, true);
+        
+        try
+		{
+			/*
+			 * Depending on the camera app it might be possible to get the orientation
+			 * of the image from its EXIF data. Pass the level of rotation to the crop
+			 * activity so it can be shown the right way up.
+			 */
+			ExifInterface exif = new ExifInterface(mFileTemp.getPath());
+			int exifOrientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, -1);
+			switch (exifOrientation)
+			{
+				case ExifInterface.ORIENTATION_NORMAL:
+					intent.putExtra(CropImage.ROTATION_IN_DEGREES, 0f);
+					break;
+				case ExifInterface.ORIENTATION_ROTATE_90:
+					intent.putExtra(CropImage.ROTATION_IN_DEGREES, 90f);
+					break;
+				case ExifInterface.ORIENTATION_ROTATE_180:
+					intent.putExtra(CropImage.ROTATION_IN_DEGREES, 180f);
+					break;
+				case ExifInterface.ORIENTATION_ROTATE_270:
+					intent.putExtra(CropImage.ROTATION_IN_DEGREES, -90f);
+					break;
+			}
+		}
+		catch (IOException e)
+		{
+			e.printStackTrace();
+		}
 
         intent.putExtra(CropImage.ASPECT_X, 3);
         intent.putExtra(CropImage.ASPECT_Y, 2);

--- a/simple-crop-image-lib/src/eu/janmuller/android/simplecropimage/CropImage.java
+++ b/simple-crop-image-lib/src/eu/janmuller/android/simplecropimage/CropImage.java
@@ -63,6 +63,7 @@ public class CropImage extends MonitoredActivity {
     public static final  String SCALE                  = "scale";
     public static final  String ORIENTATION_IN_DEGREES = "orientation_in_degrees";
     public static final  String ASPECT_X               = "aspectX";
+    public static final  String ROTATION_IN_DEGREES    = "rotation_in_degrees";
     public static final  String ASPECT_Y               = "aspectY";
     public static final  String OUTPUT_X               = "outputX";
     public static final  String OUTPUT_Y               = "outputY";
@@ -79,6 +80,7 @@ public class CropImage extends MonitoredActivity {
     private       boolean               mCircleCrop      = false;
     private final Handler               mHandler         = new Handler();
 
+    private float           mRotation;
     private int             mAspectX;
     private int             mAspectY;
     private int             mOutputX;
@@ -147,6 +149,9 @@ public class CropImage extends MonitoredActivity {
 
                 throw new IllegalArgumentException("aspect_y must be integer");
             }
+                
+            mRotation = extras.getFloat(ROTATION_IN_DEGREES);
+            
             mOutputX = extras.getInt(OUTPUT_X);
             mOutputY = extras.getInt(OUTPUT_Y);
             mScale = extras.getBoolean(SCALE, true);
@@ -160,6 +165,10 @@ public class CropImage extends MonitoredActivity {
             finish();
             return;
         }
+        
+        if (mRotation > 0) {
+            mBitmap = Util.rotateImage(mBitmap, mRotation);
+		}
 
         // Make UI fullscreen.
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);


### PR DESCRIPTION
Added an addition intent extra for the crop view which can be used to pre-rotate the image before it is displayed. This is very useful, for example, when displaying a photo taken in portrait mode as the photo EXIF data can be read and used to correctly orient the image for cropping (see #16).
