### PR TITLE
Correct minSdkVersion to 8 (was 15)

### DIFF
--- a/simple-crop-image-lib/build.gradle
+++ b/simple-crop-image-lib/build.gradle
@@ -18,7 +18,7 @@ android {
   compileSdkVersion 17
   buildToolsVersion "17.0"
   defaultConfig {
-    minSdkVersion 15
+    minSdkVersion 8
     targetSdkVersion 15
   }
   sourceSets {


### PR DESCRIPTION
In simple-crop-image-lib/build.gradle, minSdkVersion was wrongly 15, so I corrected it to 8.
