### PR TITLE
Handled rotation before cropping and saving the image

### DIFF
--- a/simple-crop-image-lib/src/eu/janmuller/android/simplecropimage/CropImage.java
+++ b/simple-crop-image-lib/src/eu/janmuller/android/simplecropimage/CropImage.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.CountDownLatch;
+import android.media.ExifInterface;
 
 import android.app.Activity;
 import android.content.ContentResolver;
@@ -129,9 +130,16 @@ public class CropImage extends MonitoredActivity {
             }
 
             mImagePath = extras.getString(IMAGE_PATH);
+            int rotation = getImageOrientation(mImagePath);
 
             mSaveUri = getImageUri(mImagePath);
             mBitmap = getBitmap(mImagePath);
+
+            if(rotation!=0){
+              mBitmap = Util.rotateImage(mBitmap, rotation);
+              RotateBitmap rotateBitmap = new RotateBitmap(mBitmap);
+              mImageView.setImageRotateBitmapResetBase(rotateBitmap, true);
+            }
 
             if (extras.containsKey(ASPECT_X) && extras.get(ASPECT_X) instanceof Integer) {
 
@@ -207,6 +215,30 @@ public class CropImage extends MonitoredActivity {
                 });
         startFaceDetection();
     }
+
+    public static int getImageOrientation(String imagePath){
+      int rotate = 0;
+       try {
+           File imageFile = new File(imagePath);
+           ExifInterface exif = new ExifInterface(imageFile.getAbsolutePath());
+           int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION,
+                                                  ExifInterface.ORIENTATION_NORMAL);
+           switch (orientation) {
+              case ExifInterface.ORIENTATION_ROTATE_270:
+                  rotate = 270;
+                  break;
+             case ExifInterface.ORIENTATION_ROTATE_180:
+                  rotate = 180;
+                  break;
+             case ExifInterface.ORIENTATION_ROTATE_90:
+                  rotate = 90;
+                  break;
+          }
+       } catch (IOException e) {
+          e.printStackTrace();
+         }
+         return rotate;
+}
 
     private Uri getImageUri(String path) {
 


### PR DESCRIPTION
In samsung S4 when we are taking photos in portrait mode its rotating the image by 90 degrees, so used EXIF data to check the degrees by which image is rotated, and then rotating the image in reverse direction by same degrees to avoid this.
